### PR TITLE
Add router.sh to unstable prepare

### DIFF
--- a/src/common/bootstrap.sh
+++ b/src/common/bootstrap.sh
@@ -1,1 +1,0 @@
-# Bootstrap script will be sourced from a prepare stage job to copy required files in to place from an extracted tarball

--- a/src/prepare-unstable.sh
+++ b/src/prepare-unstable.sh
@@ -24,18 +24,16 @@ build_lib_scripts="common/blockchain.sh
   go-chaincode/build.sh
   go-chaincode/deploy.sh
   go-chaincode/test.sh
-  build.sh
-  deploy.sh
-  test.sh"
+  router.sh"
 
 mkdir -p ${SCRIPT_DIR:=./scripts/}
 
 for script in $build_lib_scripts; do
-  script_src="${SCRIPT_URL:=https://raw.githubusercontent.com/IBM-Blockchain-Starter-Kit/build-lib/master/scripts}/${script}"
+  script_src="${SCRIPT_URL:=https://raw.githubusercontent.com/IBM-Blockchain-Starter-Kit/build-lib/master/src}/${script}"
   script_file="${SCRIPT_DIR}${script}"
   
   if [ ! -f  ${script_file} ]; then
     mkdir -p $(dirname "${script_file}")
-    (curl -sSL ${script_src}) > ${script_file}
+    (curl -fsSL ${script_src}) > ${script_file}
   fi
 done

--- a/test/prepare-unstable.bats
+++ b/test/prepare-unstable.bats
@@ -28,12 +28,7 @@ setup() {
 @test "prepare-unstable.sh: should only create expected script files" {
   run "${src_dir}/prepare-unstable.sh"
 
-  ls -R "${testcase_dirname}"
-  assert_build_scripts_exist "${SCRIPT_DIR}"
-
-  file_count=$(count_files "${testcase_dirname}")
-  echo "file_count = ${file_count}"
-  [ $file_count -eq 13 ]
+  assert_build_scripts_exist "${src_dir}" "${SCRIPT_DIR}"
 }
 
 @test "prepare-unstable.sh: should not overwrite existing scripts in SCRIPT_DIR" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,32 +1,8 @@
 #!/usr/bin/env bash
 
-function count_files {
-  # Recursively count files under the specified directory
-  test_dirname=$1
-
-  echo $(cd "${test_dirname}" && find .//. -type f ! -name . -print | grep -c //)
-}
-
 function assert_build_scripts_exist {
-  test_dirname=$1
+  src_dirname="$1"
+  test_dirname="$2"
   
-  build_lib_scripts="common/blockchain.sh
-    common/cloudant.sh
-    common/env.sh
-    common/utils.sh
-    composer/build.sh
-    composer/deploy.sh
-    composer/test.sh
-    go-chaincode/build.sh
-    go-chaincode/deploy.sh
-    go-chaincode/test.sh
-    build.sh
-    deploy.sh
-    test.sh"
-
-  for script in $build_lib_scripts; do
-    script_path="${test_dirname}/${script}"
-    echo "${script_path} should exist"
-    [ -f "${script_path}" ]
-  done
+  diff -r --exclude prepare-*.sh "$src_dirname" "$test_dirname"
 }


### PR DESCRIPTION
Last commit should have broken the tests since the
prepare-unstable.sh script wasn't updated to handle the new
router.sh script

Updated tests to improve script checks and fixed prepare script

Signed-off-by: James Taylor <jamest@uk.ibm.com>