### PR TITLE
Add get_deploy_name utility function

### DIFF
--- a/scripts/pipeline-COMMON.sh
+++ b/scripts/pipeline-COMMON.sh
@@ -37,3 +37,23 @@ function do_curl {
         return ${HTTP_STATUS}
     fi
 }
+
+# Creates a name that is likely to be unique, which is suitable for use
+# when deploying apps to bluemix
+#   get_deploy_name <uuid> [<name> ...]
+function get_deploy_name {
+    uuid="${1:?get_deploy_name must be called with at least one argument}"
+    shift
+
+    old_ifs="$IFS"
+    IFS='_'
+    name="$*"
+    IFS=$old_ifs
+
+    unique_name="${name}_${uuid}"
+
+    short_hash=$(echo "${unique_name}" | git hash-object --stdin | head -c 7)
+
+    deploy_name=$(echo "${name}" | head -c 43)${short_hash}
+    echo "${deploy_name}"
+}

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -1,3 +1,21 @@
 #!/usr/bin/env bash
 
-# Common utility functions, e.g. to make curl requests
+# Creates a name that is likely to be unique, which is suitable for use
+# when deploying apps to bluemix
+#   get_deploy_name <uuid> [<name> ...]
+function get_deploy_name {
+    uuid="${1:?get_deploy_name must be called with at least one argument}"
+    shift
+
+    old_ifs="$IFS"
+    IFS='_'
+    name="$*"
+    IFS=$old_ifs
+
+    unique_name="${name}_${uuid}"
+
+    short_hash=$(echo "${unique_name}" | git hash-object --stdin | head -c 7)
+
+    deploy_name=$(echo "${name}" | head -c 43)${short_hash}
+    echo "${deploy_name}"
+}

--- a/test/common/utils.bats
+++ b/test/common/utils.bats
@@ -1,5 +1,44 @@
 #!/usr/bin/env bats
 
-@test "Placeholder util test script" {
-  skip
+load ../test_helper
+
+setup() {
+  src_dir="${BATS_TEST_DIRNAME}/../../src"
+  testcase_dirname="$(mktemp -d)"
+
+  setup_script_dir "${src_dir}" "${testcase_dirname}"
+
+  source "${SCRIPT_DIR}/common/utils.sh"
+}
+
+@test "utils.sh: get_deploy_name should create a stable deploy name" {
+  run get_deploy_name 20354d7a-e4fe-47af-8ff6-187bca92f3f9 toolchain-name network-name
+
+  echo "output = ${output}"
+  [ $status -eq 0 ]
+  [ "${output}" = "toolchain-name_network-name0b9eb32" ]
+}
+
+@test "utils.sh: get_deploy_name should create a stable deploy name of 50 charaters maximum" {
+  run get_deploy_name 20354d7a-e4fe-47af-8ff6-187bca92f3f9 toolchain-name looooooooooooooooooooooooooon-network-name
+
+  echo "output = ${output}"
+  [ $status -eq 0 ]
+  [ "${output}" = "toolchain-name_looooooooooooooooooooooooooo188ed9f" ]
+}
+
+@test "utils.sh: get_deploy_name should work with a single argument" {
+  run get_deploy_name 20354d7a-e4fe-47af-8ff6-187bca92f3f9
+
+  echo "output = ${output}"
+  [ $status -eq 0 ]
+  [ "${output}" = "f95e52b" ]
+}
+
+@test "utils.sh: get_deploy_name should fail with no arguments" {
+  run get_deploy_name
+
+  echo "output = ${output}"
+  [ $status -eq 1 ]
+  echo "$output" | grep 'get_deploy_name must be called with at least one argument$'
 }


### PR DESCRIPTION
Include the new function in old style scripts to fix current
problem if rest server hostname clashes. Also updates
REST_SERVER_URLS env var format to work with vehicle
manufacture sample.

Closes #18

Signed-off-by: James Taylor <jamest@uk.ibm.com>