### PR TITLE
Add stable prepare script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bats/
 bats-mock/
+
+*.tgz

--- a/src/prepare.sh
+++ b/src/prepare.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#
+# This pipeline script must be included directly in the pipeline yaml
+# definition in order to fetch released versions of the common
+# blockchain build scripts.
+#
+# See also: prepare-unstable.sh
+#
+# Alternatively, download and extract the scripts directly in the
+# repository you are building. Once they are in your own repository you
+# can modify them to suit your own build requirements.
+#
+
+set -ex
+
+if [ -n "$BUILD_LIB_URL" ]; then
+  build_lib_dir=$(mktemp -d)
+
+  (curl -fsSL ${BUILD_LIB_URL}) > ${build_lib_dir}/blockchain-build-lib.tgz
+
+  mkdir -p $SCRIPT_DIR
+  tar --keep-old-files -xvzf ${build_lib_dir}/blockchain-build-lib.tgz -C $SCRIPT_DIR > /dev/null 2>&1 || true
+fi

--- a/test/prepare-unstable.bats
+++ b/test/prepare-unstable.bats
@@ -87,6 +87,7 @@ stub_curl_without_router() {
 
   run "${src_dir}/prepare-unstable.sh"
 
+  head -n 1 "${SCRIPT_DIR}router.sh"
   cat "${SCRIPT_DIR}router.sh" | grep -Fxq 'DO NOT OVERWRITE'
 
   unstub curl

--- a/test/prepare.bats
+++ b/test/prepare.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+load "${BATS_TEST_DIRNAME}/../bats-mock/stub.bash"
+load test_helper
+
+setup() {
+  src_dir="${BATS_TEST_DIRNAME}/../src"
+  testcase_dirname="$(mktemp -d)"
+
+  export SCRIPT_URL="https://example.org/scripts"
+  export SCRIPT_DIR="${testcase_dirname}/script_dir/"
+}
+
+stub_curl() {
+  stub curl "-fsSL https://example.org/toolchain-script-lib.tgz : tar --exclude prepare*.sh -C ${src_dir} -cvzf - ."
+}
+
+@test "prepare.sh: should exist and be executable" {
+  [ -x "${src_dir}/prepare.sh" ]
+}
+
+@test "prepare.sh: should not attempt to fetch scripts if BUILD_LIB_URL is not set" {
+  stub curl "true"
+
+  run ${src_dir}/prepare.sh
+
+  echo $output
+  [ $status -eq 0 ]
+
+  [ ! -e ${SCRIPT_DIR} ]
+
+  unstub curl || true
+}
+
+@test "prepare.sh: should fetch scripts from BUILD_LIB_URL" {
+  stub_curl
+
+  BUILD_LIB_URL='https://example.org/toolchain-script-lib.tgz' \
+    run ${src_dir}/prepare.sh
+
+  echo $output
+  [ $status -eq 0 ]
+
+  ls -al ${SCRIPT_DIR}
+
+  assert_build_scripts_exist "${src_dir}" "${SCRIPT_DIR}"
+
+  unstub curl
+}
+
+@test "prepare.sh: should not overwrite existing scripts in SCRIPT_DIR" {
+  stub_curl
+
+  mkdir -p "${SCRIPT_DIR}"
+  echo "DO NOT OVERWRITE" > "${SCRIPT_DIR}router.sh"
+
+  BUILD_LIB_URL='https://example.org/toolchain-script-lib.tgz' \
+    run ${src_dir}/prepare.sh
+
+  head -n 1 "${SCRIPT_DIR}router.sh"
+  cat "${SCRIPT_DIR}router.sh" | grep -Fxq 'DO NOT OVERWRITE'
+
+  unstub curl
+}
+
+@test "prepare.sh: should fail tarball cannot be fetched from BUILD_LIB_URL" {
+  BUILD_LIB_URL='https://example.org/toolchain-script-lib.tgz' \
+    run ${src_dir}/prepare.sh
+
+  echo "status = $status"
+  echo $output
+  [ $status -eq 22 ]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -4,7 +4,7 @@ assert_build_scripts_exist() {
   src_dirname="$1"
   test_dirname="$2"
   
-  diff -r --exclude prepare-*.sh "$src_dirname" "$test_dirname"
+  diff -r --exclude prepare*.sh "$src_dirname" "$test_dirname"
 }
 
 setup_script_dir() {


### PR DESCRIPTION
Add stable version of the prepare script which fetches released
build scripts via a tarball rather than fetching raw files
directly from github

Closes #5

Signed-off-by: James Taylor <jamest@uk.ibm.com>