### PR TITLE
Add stub cleanup helper

### DIFF
--- a/test/common/env.bats
+++ b/test/common/env.bats
@@ -1,6 +1,5 @@
 #!/usr/bin/env bats
 
-load "${BATS_TEST_DIRNAME}/../../bats-mock/stub.bash"
 load ../test_helper
 
 setup() {

--- a/test/go-chaincode/build.bats
+++ b/test/go-chaincode/build.bats
@@ -10,6 +10,10 @@ setup() {
   setup_script_dir "${src_dir}" "${testcase_dirname}"
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 @test "build.sh: should exist and be executable" {
   [ -x "${SCRIPT_DIR}/go-chaincode/build.sh" ]
 }

--- a/test/go-chaincode/download-fabric.bats
+++ b/test/go-chaincode/download-fabric.bats
@@ -12,6 +12,10 @@ setup() {
   export HLF_VERSION=9.9.9
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 @test "download-fabric.sh: should exist and be executable" {
   [ -x "${SCRIPT_DIR}/go-chaincode/download-fabric.sh" ]
 }

--- a/test/go-chaincode/install-go.bats
+++ b/test/go-chaincode/install-go.bats
@@ -11,6 +11,10 @@ setup() {
   export GO_VERSION=9.9.9
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 @test "install-go.sh: should exist and be executable" {
   [ -x "${SCRIPT_DIR}/go-chaincode/install-go.sh" ]
 }

--- a/test/go-chaincode/test.bats
+++ b/test/go-chaincode/test.bats
@@ -10,6 +10,10 @@ setup() {
   setup_script_dir "${src_dir}" "${testcase_dirname}"
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 @test "test.sh: should exist and be executable" {
   [ -x "${SCRIPT_DIR}/go-chaincode/test.sh" ]
 }

--- a/test/prepare-unstable.bats
+++ b/test/prepare-unstable.bats
@@ -11,6 +11,10 @@ setup() {
   export SCRIPT_DIR="${testcase_dirname}/script_dir/"
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 stub_curl_all() {
   stub curl \
     "-fsSL https://example.org/scripts/common/blockchain.sh : cat ${src_dir}/common/blockchain.sh" \

--- a/test/prepare.bats
+++ b/test/prepare.bats
@@ -11,6 +11,10 @@ setup() {
   export SCRIPT_DIR="${testcase_dirname}/script_dir/"
 }
 
+teardown() {
+  cleanup_stubs
+}
+
 stub_curl() {
   stub curl "-fsSL https://example.org/toolchain-script-lib.tgz : tar --exclude prepare*.sh -C ${src_dir} -cvzf - ."
 }

--- a/test/router.bats
+++ b/test/router.bats
@@ -1,6 +1,5 @@
 #!/usr/bin/env bats
 
-load "${BATS_TEST_DIRNAME}/../bats-mock/stub.bash"
 load test_helper
 
 setup() {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -16,3 +16,12 @@ setup_script_dir() {
   mkdir -p "${SCRIPT_DIR}"
   cp -a "${src_dirname}/"* "${SCRIPT_DIR}"
 }
+
+cleanup_stubs() {
+  if stat ${BATS_TMPDIR}/*-stub-plan >/dev/null 2>&1; then
+    for file in ${BATS_TMPDIR}/*-stub-plan; do
+      program=$(basename $(echo "$file" | rev | cut -c 11- | rev))
+      unstub $program || true
+    done
+  fi
+}


### PR DESCRIPTION
Add stub cleanup helper function for use in teardown functions to
remove any leftover stubs from failing testcases

Closes #38

Signed-off-by: James Taylor <jamest@uk.ibm.com>