### PR TITLE
Update travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ script:
   - PATH="./bats/bin:$PATH" bats test/*
 before_deploy:
   - tar --exclude prepare*.sh -C src -cvzf blockchain-build-lib.tgz .
-  - tar --exclude pipeline-PREPARE.sh --exclude chaincode-pipeline -C scripts -cvzf sample-blockchain-build-lib.tgz .
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
   file:
     - "blockchain-build-lib.tgz"
-    - "sample-blockchain-build-lib.tgz"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
Remove legacy sample release tarball since old scripts should no longer be changing, other than to be deleted

Contributes to #75

Signed-off-by: James Taylor <jamest@uk.ibm.com>