### PR TITLE
Chanincode component may contain folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 bats/
 bats-mock/
-
 *.tgz
+**/.DS_Store 

--- a/src/common/blockchain.sh
+++ b/src/common/blockchain.sh
@@ -237,8 +237,6 @@ function install_fabric_chaincode {
     local CC_PATH=$3
     local CC_TYPE=$4
 
-    local CHAINCODE_FILES
-
     echo "Installing chaincode '$CC_PATH' with id '$CC_ID' and version '$CC_VERSION'..."
     
     # Cannot leave behind folders... for instance, a chaincode component
@@ -247,8 +245,8 @@ function install_fabric_chaincode {
     pushd "$CC_PATH"
     CC_ZIP_FILE="${CC_ID}.zip"
     echo "Creating ZIP file for chaincode: ${CC_ZIP_FILE}"
-    zip -r "$CC_ZIP_FILE" *
-    #zip -r "$CC_ZIP_FILE" * -x "*test*"
+    zip -r "$CC_ZIP_FILE" ./*
+    #zip -r "$CC_ZIP_FILE" ./* -x "*test*"
 
     # shellcheck disable=2086
     OUTPUT=$(do_curl \

--- a/src/common/blockchain.sh
+++ b/src/common/blockchain.sh
@@ -244,11 +244,11 @@ function install_fabric_chaincode {
     # Cannot leave behind folders... for instance, a chaincode component
     # may have additional files such as CouchDB index files.
     # Hence, including all folders and files
-    pushd $CC_PATH
+    pushd "$CC_PATH"
     CC_ZIP_FILE="${CC_ID}.zip"
     echo "Creating ZIP file for chaincode: ${CC_ZIP_FILE}"
-    zip -r $CC_ZIP_FILE *
-    #zip -r $CC_ZIP_FILE * -x "*test*"
+    zip -r "$CC_ZIP_FILE" *
+    #zip -r "$CC_ZIP_FILE" * -x "*test*"
 
     # shellcheck disable=2086
     OUTPUT=$(do_curl \
@@ -259,7 +259,7 @@ function install_fabric_chaincode {
         -F chaincode_type="${CC_TYPE}" \
         "${BLOCKCHAIN_API}/chaincode/install")
 
-    rm $CC_ZIP_FILE
+    rm "$CC_ZIP_FILE"
     popd
     
     if [ $? -eq 1 ]

--- a/src/common/blockchain.sh
+++ b/src/common/blockchain.sh
@@ -256,11 +256,12 @@ function install_fabric_chaincode {
         -F chaincode_id="${CC_ID}" -F chaincode_version="${CC_VERSION}" \
         -F chaincode_type="${CC_TYPE}" \
         "${BLOCKCHAIN_API}/chaincode/install")
+    RET_CODE=$?
 
-    rm "$CC_ZIP_FILE"
+    rm -f "$CC_ZIP_FILE"
     popd
     
-    if [ $? -eq 1 ]
+    if [ $RET_CODE -eq 1 ]
     then
         echo "Failed to install fabric contract:"
         if [[ "${OUTPUT}" == *"chaincode code"*"exists"* ]]

--- a/test/common/blockchain.bats
+++ b/test/common/blockchain.bats
@@ -382,16 +382,17 @@ cleanup_blockchain_json() {
   echo "true" > "${SCRIPT_DIR}/common/utils.sh"
 
   stub do_curl "exit 0"
-  stub find "echo contract.go"
-
+  stub zip "echo ZIP file created!"
+      
   source "${SCRIPT_DIR}/common/blockchain.sh"
-  run install_fabric_chaincode "ccid" "ccversion" "ccpath"
+  CCPATH=$(pwd)
+  run install_fabric_chaincode "ccid" "ccversion" "$CCPATH"
 
-  [ "${lines[1]}" = "Successfully installed fabric contract." ]
+  [ "${lines[5]}" = "Successfully installed fabric contract." ]
   [ $status -eq 0 ]
 
+  unstub zip
   unstub do_curl
-  unstub find
 }
 
 @test "blockchain.sh: install_fabric_chaincode should return status 1 if unrecognized error is received" {
@@ -400,56 +401,36 @@ cleanup_blockchain_json() {
   error_msg="error"
 
   stub do_curl "echo ${error_msg}; exit 1"
-  stub find "echo contract.go"
+  stub zip "echo ZIP file created!"
 
   source "${SCRIPT_DIR}/common/blockchain.sh"
-  run install_fabric_chaincode "ccid" "ccversion" "ccpath"
+  CCPATH=$(pwd)
+  run install_fabric_chaincode "ccid" "ccversion" "$CCPATH"
 
-  [ "${lines[1]}" = "Failed to install fabric contract:" ]
-  [ "${lines[2]}" = "Unrecognized error returned:" ]
-  [ "${lines[3]}" = "${error_msg}" ]
+  [ "${lines[5]}" = "Failed to install fabric contract:" ]
+  [ "${lines[6]}" = "Unrecognized error returned:" ]
+  [ "${lines[7]}" = "${error_msg}" ]
   [ $status -eq 1 ]
 
+  unstub zip
   unstub do_curl
-  unstub find
 }
 
 @test "blockchain.sh: install_fabric_chaincode should return status 2 if already installed with specified version and id" {
   echo "true" > "${SCRIPT_DIR}/common/utils.sh"
 
   stub do_curl "echo chaincode code exists; exit 1"
-  stub find "echo contract.go"
+  stub zip "echo ZIP file created!"
 
   source "${SCRIPT_DIR}/common/blockchain.sh"
-  run install_fabric_chaincode "ccid" "ccversion" "ccpath"
+  CCPATH=$(pwd)
+  run install_fabric_chaincode "ccid" "ccversion" "$CCPATH"
 
-  [ "${lines[1]}" = "Failed to install fabric contract:" ]
-  [ "${lines[2]}" = "Chaincode already installed with id 'ccid' and version 'ccversion'" ]
+  [ "${lines[5]}" = "Failed to install fabric contract:" ]
+  [ "${lines[6]}" = "Chaincode already installed with id 'ccid' and version 'ccversion'" ]
   [ $status -eq 2 ]
 
-  unstub do_curl
-  unstub find
-}
-
-@test "blockchain.sh: install_fabric_chaincode should correctly build array of files from directory path" {
-  echo "true" > "${SCRIPT_DIR}/common/utils.sh"
-
-  stub do_curl "exit 0"
-
-  source "${SCRIPT_DIR}/common/blockchain.sh"
-
-  pushd "${SCRIPT_DIR}/.."
-  mkdir -p "cc/path"
-  touch "cc/path/contract.go"
-  touch "cc/path/contract_test.go"
-  touch "cc/path/notchaincode.txt"
-
-  install_fabric_chaincode "ccid" "ccversion" "cc/path"
-  popd
-
-  [[ "${CHAINCODE_FILE_OPTS}" == ?"-F files[]=@cc/path/notchaincode.txt -F files[]=@cc/path/contract.go" ]] || \
-  [[ "${CHAINCODE_FILE_OPTS}" == ?"-F files[]=@cc/path/contract.go -F files[]=@cc/path/notchaincode.txt" ]]
-
+  unstub zip
   unstub do_curl
 }
 


### PR DESCRIPTION
The current implementation leaves behind any folders that exist in the chaincode component. This creates problems when, for instance, installing a chaincode component that uses indexes for CouchDB (for further details see [this](https://hyperledger-fabric.readthedocs.io/en/release-1.2/couchdb_tutorial.html#add-the-index-to-your-chaincode-folder)).

This PR addresses the existing limitation; we are in the middle of an MVP and need this functionality asap.

@jorgedr94 - As we discussed, this is the first PR. In a future PR, we can add the logic for allowing the developer to specify a pattern that specifies which files/folders can be left behind. I have a few ideas on how to implement this; let's discuss them in person.

@jorgedr94 - I need to update the test cases... so still work in progress.