### PR TITLE
Go chaincode test - Need assert and go-junit-report packages

### DIFF
--- a/src/common/env.sh
+++ b/src/common/env.sh
@@ -11,6 +11,7 @@ export NVM_VERSION=${NVM_VERSION:="0.33.11"}
 export GOROOT=${ROOTDIR}/go
 export PATH=${GOROOT}/bin:$PATH
 export GOPATH=${ROOTDIR}
+export PATH=${GOPATH}/bin:$PATH
 
 export CONFIGPATH=${CONFIGPATH:="deploy_config.json"}
 export CHAINCODEPATH=${CHAINCODEPATH:="chaincode"}

--- a/src/go-chaincode/test.sh
+++ b/src/go-chaincode/test.sh
@@ -13,5 +13,5 @@ go get github.com/stretchr/testify/assert
 go get -u github.com/jstemmer/go-junit-report
 # Run test cases and send output/results to terminal and go-junit-report
 #go test -v "chaincode/..."
-go test -v "chaincode/..." 2>&1 | tee raw-output.txt | $GOPATH/bin/go-junit-report > TEST-report.xml
+go test -v "chaincode/..." 2>&1 | tee raw-output.txt | "$GOPATH"/bin/go-junit-report > TEST-report.xml
 cat raw-output.txt

--- a/src/go-chaincode/test.sh
+++ b/src/go-chaincode/test.sh
@@ -7,4 +7,10 @@ source "${SCRIPT_DIR}/common/env.sh"
 
 $DEBUG && set -x
 
-go test -v "chaincode/..." 
+# Install assert package for GO (needed for testing)
+go get github.com/stretchr/testify/assert
+# Install go-junit-report
+go get -u github.com/jstemmer/go-junit-report
+# Run test cases and send output/results to terminal and go-junit-report
+#go test -v "chaincode/..."
+go test -v "chaincode/..." 2>&1 | tee /dev/tty | $GOPATH/bin/go-junit-report > TEST-report.xml

--- a/src/go-chaincode/test.sh
+++ b/src/go-chaincode/test.sh
@@ -13,6 +13,5 @@ go get github.com/stretchr/testify/assert
 go get -u github.com/jstemmer/go-junit-report
 # Run test cases and send results to go-junit-report
 #go test -v "chaincode/..."
-PATH="$GOPATH/bin":$PATH
-go test -v "chaincode/..." 2>&1 | tee raw-output.txt | go-junit-report > TEST-report.xml
-cat raw-output.txt
+go test -v "chaincode/..." 2>&1 | tee tst-output.txt | go-junit-report > TEST-report.xml
+cat tst-output.txt

--- a/src/go-chaincode/test.sh
+++ b/src/go-chaincode/test.sh
@@ -13,4 +13,5 @@ go get github.com/stretchr/testify/assert
 go get -u github.com/jstemmer/go-junit-report
 # Run test cases and send output/results to terminal and go-junit-report
 #go test -v "chaincode/..."
-go test -v "chaincode/..." 2>&1 | tee /dev/tty | $GOPATH/bin/go-junit-report > TEST-report.xml
+go test -v "chaincode/..." 2>&1 | tee raw-output.txt | $GOPATH/bin/go-junit-report > TEST-report.xml
+cat raw-output.txt

--- a/src/go-chaincode/test.sh
+++ b/src/go-chaincode/test.sh
@@ -11,7 +11,8 @@ $DEBUG && set -x
 go get github.com/stretchr/testify/assert
 # Install go-junit-report
 go get -u github.com/jstemmer/go-junit-report
-# Run test cases and send output/results to terminal and go-junit-report
+# Run test cases and send results to go-junit-report
 #go test -v "chaincode/..."
-go test -v "chaincode/..." 2>&1 | tee raw-output.txt | "$GOPATH"/bin/go-junit-report > TEST-report.xml
+PATH="$GOPATH/bin":$PATH
+go test -v "chaincode/..." 2>&1 | tee raw-output.txt | go-junit-report > TEST-report.xml
 cat raw-output.txt

--- a/test/go-chaincode/test.bats
+++ b/test/go-chaincode/test.bats
@@ -19,7 +19,11 @@ teardown() {
 }
 
 @test "test.sh: should run without errors" {
-  stub go "test -v chaincode/... : true"
+  stub go \
+    "get github.com/stretchr/testify/assert : true" \
+    "get -u github.com/jstemmer/go-junit-report : true" \
+    "test -v chaincode/... : true"
+  stub go-junit-report "echo 'GO tests resports created!'"
 
   run "${SCRIPT_DIR}/go-chaincode/test.sh"
 
@@ -27,4 +31,5 @@ teardown() {
   [ $status -eq 0 ]
 
   unstub go
+  unstub go-junit-report
 }


### PR DESCRIPTION
Once GO has an official package dependency tool, this issue should be quite easy to address.

In the meantime, for testing, we need an assert package. Also, to visually report the test results (in the DevOps pipeline), we need go-junit-report. Hence, the need for this PR.

We are in the middle of an MVP and need this functionality asap.

@jorgedr94 - As we discussed, here's the second PR. In a future PR, we can add more flexibility (for instance, we can make configurable the name of the XML file that includes the test report).

@jorgedr94 - I need to update the test cases... so still work in progress.