### PR TITLE
Added support to vendor in (GO) packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
 # build-lib
 
-Common scripts for use in Blockchain build pipelines
+This repository contains common scripts for use in Blockchain build pipelines.
 
 ## Unit tests
 
 This project is tested using Bats when making pull requests.
 
-To run the tests locally, install
-[bats-core](https://github.com/bats-core/bats-core) and
-[bats-mock](https://github.com/jasonkarns/bats-mock), then run the following
-command from the uppermost directory:
+To run the tests locally, install [bats-core](https://github.com/bats-core/bats-core) and [bats-mock](https://github.com/jasonkarns/bats-mock). Here are a few tips on installing these two libraries so you don't go into a rabbit hole when attempting to run the test cases.
+
+### bats-core
+
+You should [install](https://github.com/bats-core/bats-core#installing-bats-from-source) bats-core from source. After you have cloned `bats-core` into the directory of your choosing, navigate to that folder and run the `./install.sh` script by passing the absolute path to the folder where this repository (i.e. `build-lib`) was cloned into your local system and appending `bats` folder to that path as shown below:
+
+```
+./install.sh <absolute path to the build-lib repository>/bats
+```
+
+Executing the `install.sh` script should result in the creation of a `bats` folder under the `build-lib` repository; this `bats` folder contains the `bats-core` files.
+
+### bats-mock
+To install `bats-mock`, first create an empty folder named `bats-mock` under the `build-lib` repository. Then clone the [bats-mock](https://github.com/jasonkarns/bats-mock) repository into the directory of your choosing; navigate to that folder, copy the `binstub` and `stub.bash` files into the `bats-mock` you created under the `build-lib` repository.
+
+### Running test cases
+Once you have installed `bats-core` and `bats-mock` as described the sections above, you can then run the following command from the root directory of this repository:
 
 ```
 PATH="./bats/bin:$PATH" bats test/*

--- a/src/go-chaincode/deploy.sh
+++ b/src/go-chaincode/deploy.sh
@@ -8,6 +8,7 @@ source "${SCRIPT_DIR}/common/env.sh"
 source "${SCRIPT_DIR}/common/utils.sh"
 # shellcheck source=src/common/blockchain.sh
 source "${SCRIPT_DIR}/common/blockchain.sh"
+source "${SCRIPT_DIR}/go-chaincode/vendor-dependencies.sh"
 
 $DEBUG && set -x
 
@@ -19,4 +20,5 @@ fi
 install_jq
 setup_service_constants
 provision_blockchain
+fetch_dependencies $CONFIGPATH
 deploy_fabric_chaincode golang $CONFIGPATH

--- a/src/go-chaincode/vendor-dependencies.sh
+++ b/src/go-chaincode/vendor-dependencies.sh
@@ -54,13 +54,17 @@ function _fetch_dependencies_cc {
         shopt -s extglob
         while (( ${#packages[@]} > index )); do
             package=${packages[index]}
-            ### Trim leading whitespaces ###
+            ## Remove newlines, carriage returns
+            package="${package//[$'\r\n']}"
+            ### Trim leading whitespaces
             package="${package##*( )}"
-            ### Trim trailing whitespaces  ##
+            ### Trim trailing whitespaces
             package="${package%%*( )}"
-            #echo "=${package}="
-            echo "Fetching ${package}"
-            govendor fetch "${package}"
+            # echo "=${package}="
+            if ! [[ -z "$package" ]]; then
+                echo "Fetching ${package}"
+                govendor fetch "${package}"
+            fi
             (( index += 1 ))
         done
         shopt -u extglob

--- a/src/go-chaincode/vendor-dependencies.sh
+++ b/src/go-chaincode/vendor-dependencies.sh
@@ -40,7 +40,7 @@ function _fetch_dependencies_cc {
     local CC_PATH=$1
     local TARGET_CC_PATH="${GOPATH}/src/$CC_PATH"
     
-    pushd $TARGET_CC_PATH
+    pushd "$TARGET_CC_PATH"
 
     if [ -f ".govendor_packages" ]; then
         echo "Found .govendor_packages file."
@@ -60,7 +60,7 @@ function _fetch_dependencies_cc {
             package="${package%%*( )}"
             #echo "=${package}="
             echo "Fetching ${package}"
-            govendor fetch ${package}
+            govendor fetch "${package}"
             (( index += 1 ))
         done
         shopt -u extglob

--- a/src/go-chaincode/vendor-dependencies.sh
+++ b/src/go-chaincode/vendor-dependencies.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# shellcheck source=src/common/env.sh
+source "${SCRIPT_DIR}/common/env.sh"
+
+# Install govendor
+go get -u github.com/kardianos/govendor
+
+#######################################
+# Parses deployment configuration -> for each organization and chaincode component,
+# it invokes the fetch_dependencies_cc function.
+# Arguments:
+#   DEPLOY_CONFIG: path to deployment JSON config file
+# Returns:
+#   None
+#######################################
+function fetch_dependencies {
+    local DEPLOY_CONFIG=$1
+
+    # Iterate over every organization and chaincode component defined in deploy config file    
+    for org in $(jq -r "to_entries[] | .key" "$DEPLOY_CONFIG")
+    do
+        echo "Processing org '$org'..."
+        jq -r ".${org}.chaincode[].path" "$DEPLOY_CONFIG" | while read -r CC_PATH
+        do
+            echo "About to fetch dependencies for '$CC_PATH'"
+            _fetch_dependencies_cc "$CC_PATH"
+        done
+    done
+}
+
+#######################################
+# Fetch dependencies for the specified chaincode component.
+# Arguments:
+#   CC_PATH: relative path to chaincode component (as defined in the deployment JSON config file)
+# Returns:
+#   None
+#######################################
+function _fetch_dependencies_cc {
+    local CC_PATH=$1
+    local TARGET_CC_PATH="${GOPATH}/src/$CC_PATH"
+    
+    pushd $TARGET_CC_PATH
+
+    if [ -f ".govendor_packages" ]; then
+        echo "Found .govendor_packages file."
+        # Initialize govendor
+        govendor init
+        # Get list of packages to vendor in
+        declare -a packages        
+        readarray packages < .govendor_packages        
+        local index=0        
+
+        shopt -s extglob
+        while (( ${#packages[@]} > index )); do
+            package=${packages[index]}
+            ### Trim leading whitespaces ###
+            package="${package##*( )}"
+            ### Trim trailing whitespaces  ##
+            package="${package%%*( )}"
+            #echo "=${package}="
+            echo "Fetching ${package}"
+            govendor fetch ${package}
+            (( index += 1 ))
+        done
+        shopt -u extglob
+
+        echo "Copying fetched dependencies to chaincode folder..."
+        cp -r vendor "$GOPATH/$CC_PATH"
+    else
+        echo "No .govendor_packages file found; no dependencies to vendor in."
+    fi
+
+    popd
+    
+    echo "Finished looking up dependencies for chaincode component."
+}

--- a/src/prepare-unstable.sh
+++ b/src/prepare-unstable.sh
@@ -20,6 +20,7 @@ build_lib_scripts="common/blockchain.sh
   common/utils.sh
   go-chaincode/build.sh
   go-chaincode/deploy.sh
+  go-chaincode/vendor-dependencies.sh
   go-chaincode/download-fabric.sh
   go-chaincode/install-go.sh
   go-chaincode/test.sh

--- a/src/prepare-unstable.sh
+++ b/src/prepare-unstable.sh
@@ -20,10 +20,10 @@ build_lib_scripts="common/blockchain.sh
   common/utils.sh
   go-chaincode/build.sh
   go-chaincode/deploy.sh
-  go-chaincode/vendor-dependencies.sh
   go-chaincode/download-fabric.sh
   go-chaincode/install-go.sh
   go-chaincode/test.sh
+  go-chaincode/vendor-dependencies.sh
   js-chaincode/build.sh
   js-chaincode/deploy.sh
   js-chaincode/test.sh

--- a/test/go-chaincode/deploy.bats
+++ b/test/go-chaincode/deploy.bats
@@ -17,8 +17,12 @@ setup() {
 @test "deploy.sh: should fail if deploy configuration does not exist" {
     export CONFIGPATH="fakepath"
 
+     stub go \
+        "get -u github.com/kardianos/govendor : true"
+
     run "${SCRIPT_DIR}/go-chaincode/deploy.sh"
-    [ "$output" = "No deploy configuration at specified path: fakepath" ]
+
+    [ "${lines[0]}" = "No deploy configuration at specified path: fakepath" ]    
     [ $status -eq 1 ]
 }
 

--- a/test/go-chaincode/vendor-dependencies.bats
+++ b/test/go-chaincode/vendor-dependencies.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load "${BATS_TEST_DIRNAME}/../../bats-mock/stub.bash"
+load ../test_helper
+
+setup() {
+    src_dir="${BATS_TEST_DIRNAME}/../../src"
+    testcase_dirname="$(mktemp -d)"
+
+    setup_script_dir "${src_dir}" "${testcase_dirname}"
+}
+
+@test "vendor-dependencies.sh: should exist and be executable" {
+    [ -x "${SCRIPT_DIR}/go-chaincode/vendor-dependencies.sh" ]
+}
+

--- a/test/prepare-unstable.bats
+++ b/test/prepare-unstable.bats
@@ -26,6 +26,7 @@ stub_curl_all() {
     "-fsSL https://example.org/scripts/go-chaincode/download-fabric.sh : cat ${src_dir}/go-chaincode/download-fabric.sh" \
     "-fsSL https://example.org/scripts/go-chaincode/install-go.sh : cat ${src_dir}/go-chaincode/install-go.sh" \
     "-fsSL https://example.org/scripts/go-chaincode/test.sh : cat ${src_dir}/go-chaincode/test.sh" \
+    "-fsSL https://example.org/scripts/go-chaincode/vendor-dependencies.sh : cat ${src_dir}/go-chaincode/vendor-dependencies.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/build.sh : cat ${src_dir}/js-chaincode/build.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/deploy.sh : cat ${src_dir}/js-chaincode/deploy.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/test.sh : cat ${src_dir}/js-chaincode/test.sh" \
@@ -43,6 +44,7 @@ stub_curl_without_router() {
     "-fsSL https://example.org/scripts/go-chaincode/download-fabric.sh : cat ${src_dir}/go-chaincode/download-fabric.sh" \
     "-fsSL https://example.org/scripts/go-chaincode/install-go.sh : cat ${src_dir}/go-chaincode/install-go.sh" \
     "-fsSL https://example.org/scripts/go-chaincode/test.sh : cat ${src_dir}/go-chaincode/test.sh" \
+    "-fsSL https://example.org/scripts/go-chaincode/vendor-dependencies.sh : cat ${src_dir}/go-chaincode/vendor-dependencies.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/build.sh : cat ${src_dir}/js-chaincode/build.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/deploy.sh : cat ${src_dir}/js-chaincode/deploy.sh" \
     "-fsSL https://example.org/scripts/js-chaincode/test.sh : cat ${src_dir}/js-chaincode/test.sh"


### PR DESCRIPTION
@jt-nti Can you review this PR?

At the moment, our chaincode pipeline (GO) does not have any support for vendoring packages. Given this limitation, our team has had [several times] to manually update the logic in the deploy script to vendor in dependencies. As you can imagine, this is tedious… and to avoid having to do this over and over again, let’s add this logic to this repo. To give you a concrete example, to leverage the [CID library](https://github.com/hyperledger/fabric/tree/release-1.2/core/chaincode/lib/cid) in a chaincode, you have to vendor it in… without the code in this PR, you’d have to manually write custom logic to vendor in this library.

BTW, this code has been successfully tested.

Note: As a future improvement to the code in this PR, we should also tackle getting libraries that are not in the Fabric binaries (this is still to be done, but first, wanted to tackle vendoring those libraries that are already in the Fabric binaries).

@jorgedr94 FYI