### PR TITLE
Deleted empty space

### DIFF
--- a/src/go-chaincode/build.sh
+++ b/src/go-chaincode/build.sh
@@ -33,7 +33,7 @@ cp -r "${CHAINCODEPATH}" "${GOSOURCE}/chaincode"
 
 # Let's put fabric source into gopath so that go can resolve dependencies with Fabric libraries 
 mkdir -p "${GOSOURCE}/github.com/hyperledger/"
-mv " ${FABRIC_SRC_DIR}" "${GOSOURCE}/github.com/hyperledger/fabric"
+mv "${FABRIC_SRC_DIR}" "${GOSOURCE}/github.com/hyperledger/fabric"
 
 
 echo "======== Building fabric-cli tool ========"


### PR DESCRIPTION
There is an excess empty space causing the pipeline to break with the following error:

`mv: cannot stat ' /home/pipeline/7ec78226-613b-4c6e-bbf7-58356797cd40/fabric-1.4.1': No such file or directory`
