### PR TITLE
fix for Private Data Collections configuration file path

### DIFF
--- a/src/common/deploy.sh
+++ b/src/common/deploy.sh
@@ -101,9 +101,15 @@ function deploy_cc() {
 
           endorsement_policy=$(jq -r ".[\"${ORG}\"].chaincode | .[${CCINDEX}] | .endorsement_policy?" "${CONFIGPATH}")
           if [[ $endorsement_policy == null ]]; then unset endorsement_policy; fi
+          
+          if [ -z "${chaincode_dir_prefix}" ]; then
+            local pdc_config_dir="${collections_config}"
+          else
+            local pdc_config_dir="${chaincode_dir_prefix}/${collections_config}"
+          fi
 
           instantiate_fabric_chaincode "${ORG}" "${ADMIN_IDENTITY_FILE}" "${CONN_PROFILE_FILE}" \
-            "${CC_NAME}" "${CC_VERSION}" "${CHANNEL}" "${platform}" "${init_fn}" "${init_args}" "${collections_config}" "${endorsement_policy}"
+            "${CC_NAME}" "${CC_VERSION}" "${CHANNEL}" "${platform}" "${init_fn}" "${init_args}" "${pdc_config_dir}" "${endorsement_policy}"
         fi
       done
     done


### PR DESCRIPTION
use the same env variable as chaincode to get the PDC configuration file.  Currently we assume that PDC configuration file will be in the chaincode git repo and will be managed via the deploy_config.json file.